### PR TITLE
add thanks command, update env, msg package and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ If you are intending to fork FCCBot to use in your own server, understand that w
 
 ## **Getting Started**
 
-
 ### **Installation**
 
 1. Clone the repository.
 2. Run `go get` to install the packages needed.
-
 
 ### **Running**
 
@@ -43,6 +41,7 @@ You will need to create .env files before running the bot: `dev.env` and `prod.e
 | LOG_CHANNEL               | The log channel's id: create a channel, and right click it                         |
 | INTRO_CHANNEL             | The introduction channel's id: create a channel, and right click it                |
 | LEARNING_RESOURCE_CHANNEL | The learning resource channel's id: create a channel, and right click it           |
+| THANKS_CHANNEL            | The thanks channel's id: create a channel, and right click it                      |
 | RFR_POST                  | The post to listen for react-for-role reactions: create a post, and right click it |
 | ROLE_VERIFIED             | The role users receive when validated: create a role, and right click it           |
 

--- a/app/command.go
+++ b/app/command.go
@@ -52,6 +52,12 @@ func (c *Commands) create() {
 		allSuccessful = false
 	}
 
+	if _, err := c.bot.Session.ApplicationCommandCreate(c.bot.Cfg.bot.id, c.bot.Cfg.server.guild, ThankCommand); err != nil {
+		c.bot.SendLog(msg.LogError, "Whilst adding thank command:")
+		c.bot.SendLog(msg.LogError, err.Error())
+		allSuccessful = false
+	}
+
 	if _, err := c.bot.Session.ApplicationCommandCreate(c.bot.Cfg.bot.id, c.bot.Cfg.server.guild, RemindCommand); err != nil {
 		c.bot.SendLog(msg.LogError, "Whilst adding remind command:")
 		c.bot.SendLog(msg.LogError, err.Error())
@@ -162,6 +168,26 @@ var LearningResourceCommand = &discordgo.ApplicationCommand{
 			Name:        "resource-description",
 			Type:        discordgo.ApplicationCommandOptionString,
 			Description: "A description of the resource. What language is it for? What can we learn from it?",
+			Required:    true,
+		},
+	},
+}
+
+var ThankCommand = &discordgo.ApplicationCommand{
+	Name:        "thanks",
+	Type:        discordgo.ChatApplicationCommand,
+	Description: "Give thanks to a member of the community",
+	Options: []*discordgo.ApplicationCommandOption{
+		{
+			Name:        "user",
+			Type:        discordgo.ApplicationCommandOptionUser,
+			Description: "Who do you want to thank?",
+			Required:    true,
+		},
+		{
+			Name:        "reason-for-thanks",
+			Type:        discordgo.ApplicationCommandOptionString,
+			Description: "Specify why you are thanking them.",
 			Required:    true,
 		},
 	},
@@ -355,7 +381,15 @@ func (c *Commands) RegularCommandGroup(s *discordgo.Session, i *discordgo.Intera
 
 			c.bot.Utils.SendResponse(i, "Thanks for posting a Learning Resource!")
 		}
+	case "thanks":
+		userToThank := options[0].UserValue(s)
+		reasonForThanks := options[1].StringValue()
 
+		messageContents := fmt.Sprintf("Thanks to %s, for helping %s with:\n %s", userToThank.Mention(), interactionMember.User.Mention(), reasonForThanks)
+		c.bot.Session.ChannelMessageSend(c.bot.Cfg.server.thanks, messageContents)
+		c.bot.SendLog(msg.LogThanks, fmt.Sprintf("%s said thanks to another user via the bot", interactionMember.User.Username))
+
+		c.bot.Utils.SendResponse(i, "Thanks for showing your appreciation!")
 	}
 }
 

--- a/app/main.go
+++ b/app/main.go
@@ -19,6 +19,7 @@ type ChannelCfg struct {
 	intros            string
 	rfr               string
 	learningResources string
+	thanks            string
 }
 
 type BotCfg struct {
@@ -84,6 +85,7 @@ func main() {
 			intros:            os.Getenv("INTRO_CHANNEL"),
 			rfr:               os.Getenv("RFR_POST"),
 			learningResources: os.Getenv("LEARNING_RESOURCE_CHANNEL"),
+			thanks:            os.Getenv("THANKS_CHANNEL"),
 		},
 		bot: BotCfg{
 			token: os.Getenv("BOT_TOKEN"),

--- a/app/msg/greetings.go
+++ b/app/msg/greetings.go
@@ -25,6 +25,7 @@ const (
 	LogError        string = "[ERROR]         "
 	LogLearning     string = "[Learning]      "
 	LogShutdown     string = "[Shutdown]      "
+	LogThanks       string = "[Thanks]        "
 )
 
 const (


### PR DESCRIPTION
## 📝 Description

Adding a `ThankCommand` and a `thanks` channel. This is in the hopes of making it easier to acknowledge people that have helped you as well as providing a place for "appreciation messages" to live within the server. 

This should both help users see who is helping others whilst also promoting helping others as its now more visibly rewarded / celebrated.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)

## 🎯 Current behaviour 

Currently there is no way to explicitly thank another user outside of leaving a thanks message or emoji.

## 🚀 New behaviour

#### 1. Use the `/thanks` command as shown below 
![image](https://github.com/devldm/fcc-bot-go/assets/39243060/8bf0bc74-b645-4818-bd50-8d7203580f47)

#### 2. Upon sending the bot responds with 
![image](https://github.com/devldm/fcc-bot-go/assets/39243060/6851f150-f932-4d11-b6c6-b6956630c059)

#### 3. The bot then sends a message to a newly created `thanks` channel as below
![image](https://github.com/devldm/fcc-bot-go/assets/39243060/6be919ba-e23e-482a-9d5f-a92e4a28b65f)

## Things to consider
- This implementation would require a new channel or re-purposing of an existing channel as a place to send these messages to.
- A `THANKS_CHANNEL` id will need to be added to local `.envs` in order to test and push out this feature as reflected in the updated `readme.md`
- While in these changes `LogThanks` has been added, this may be seen to send logs unnecessarily and could be removed without issue
- This command could likely be used in the future to send POST requests to a potential `thank-track` database as mentioned in the project-showcase channel