### PR TITLE
WIP - add initial tracking of thanks emoji in help channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ If you are intending to fork FCCBot to use in your own server, understand that w
 
 ## **Getting Started**
 
-
 ### **Installation**
 
 1. Clone the repository.
 2. Run `go get` to install the packages needed.
-
 
 ### **Running**
 
@@ -43,6 +41,7 @@ You will need to create .env files before running the bot: `dev.env` and `prod.e
 | LOG_CHANNEL               | The log channel's id: create a channel, and right click it                         |
 | INTRO_CHANNEL             | The introduction channel's id: create a channel, and right click it                |
 | LEARNING_RESOURCE_CHANNEL | The learning resource channel's id: create a channel, and right click it           |
+| HELP_CHANNEL              | The help channel's id: create a channel, and right click it           |
 | RFR_POST                  | The post to listen for react-for-role reactions: create a post, and right click it |
 | ROLE_VERIFIED             | The role users receive when validated: create a role, and right click it           |
 

--- a/app/main.go
+++ b/app/main.go
@@ -19,6 +19,7 @@ type ChannelCfg struct {
 	intros            string
 	rfr               string
 	learningResources string
+	help              string
 }
 
 type BotCfg struct {
@@ -84,6 +85,7 @@ func main() {
 			intros:            os.Getenv("INTRO_CHANNEL"),
 			rfr:               os.Getenv("RFR_POST"),
 			learningResources: os.Getenv("LEARNING_RESOURCE_CHANNEL"),
+			help:              os.Getenv("HELP_CHANNEL"),
 		},
 		bot: BotCfg{
 			token: os.Getenv("BOT_TOKEN"),


### PR DESCRIPTION
## 📝 Description

Add tracking of a specified `thanksEmoji` (in this case 🙏) in the `parseReactionAdded` and `parseReactionRemoved` functions. 

This will allow us to trigger methods when a user adds or removes a thanks emoji. In the WIP PR it simply sends a message to a server channel ID with key contents such as user, message id and thread id. 

**As a WIP this is mainly a suggestion which can be built upon or referenced in the future when building out a feature to track `thanks` reactions.**

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)

## 🎯 Current behaviour 

Currently there is no way to explicitly track thanking another user via emojis.
## 🚀 New behaviour

#### 1. Use the thanks emoji when someone helps you in a `help thread`
#### 2. Upon adding the emoji the bot sends the message `thanks added` to `x` channel
#### 3. removing the emoji will send another message showing `thanks` was removed 

## Things to consider
- This command could likely be used in the future to send POST requests to a potential `thank-track` database as mentioned in the project-showcase channel